### PR TITLE
Make supported browser list more responsive

### DIFF
--- a/translatorPage/styles.css
+++ b/translatorPage/styles.css
@@ -108,7 +108,13 @@ button.btn-pressed {
 #unsupported-popup-suguestions {
     display: flex;
     justify-content: center;
+    flex-wrap: wrapM;
     gap: 64px;
+    margin: 0 32px;
+}
+
+#unsupported-popup-suguestions img {
+    max-width: 100%;
 }
 
 #unsupported-popup-suguestions p {

--- a/translatorPage/styles.css
+++ b/translatorPage/styles.css
@@ -108,7 +108,7 @@ button.btn-pressed {
 #unsupported-popup-suguestions {
     display: flex;
     justify-content: center;
-    flex-wrap: wrapM;
+    flex-wrap: wrap;
     gap: 64px;
     margin: 0 32px;
 }


### PR DESCRIPTION
When the window is very narrow, the suggested browsers on the 'unsupported browser' warning page are now displayed on top of one another and, in extreme cases, scaled down to prevent them from overflowing.